### PR TITLE
Wrap a given storeClass with the segmentation store class

### DIFF
--- a/js/Store/SeqFeature/Segmentation.js
+++ b/js/Store/SeqFeature/Segmentation.js
@@ -63,7 +63,7 @@ function (
             let numFeatures = 0;
             const {ref, start, end} = params;
 
-            this.store.getFeatures(this, {ref, start, end}, feature => {
+            this.store.getFeatures({ref, start, end}, feature => {
                 let genotype = feature.get('genotypes');
                 let samples = Object.keys(genotype);
 

--- a/js/Store/SeqFeature/SegmentationMultiBin.js
+++ b/js/Store/SeqFeature/SegmentationMultiBin.js
@@ -4,7 +4,6 @@ define([
     'JBrowse/Store/LRUCache',
     'JBrowse/Store/SeqFeature',
     'JBrowse/Model/SimpleFeature',
-    'JBrowse/Store/SeqFeature/VCFTabix'
 ],
 function (
     declare,
@@ -12,9 +11,8 @@ function (
     LRUCache,
     SeqFeatureStore,
     SimpleFeature,
-    VCFTabix,
 ) {
-    return declare([VCFTabix, SeqFeatureStore], {
+    return declare([SeqFeatureStore], {
         constructor(args) {
             this.store = args.store;
             this.dpField = args.dpField || 'DP';
@@ -53,10 +51,9 @@ function (
                 };
                 chunks.push(chunk);
             }
-            var supermethod = this.getInherited(arguments);
 
             chunks.forEach(c => {
-                this.featureCache.get(Object.assign(c, {supermethod}), function (f, err) {
+                this.featureCache.get(c, function (f, err) {
                     if (err) {
                         errorCallback(err);
                     } else {
@@ -73,9 +70,9 @@ function (
         _readChunk(params, callback) {
             let score = 0;
             let numFeatures = 0;
-            const {supermethod, ref, start, end} = params;
+            const {ref, start, end} = params;
 
-            supermethod.call(this, {ref, start, end}, feature => {
+            this.store.getFeatures({ref, start, end}, feature => {
                 let genotype = feature.get('genotypes');
                 let samples = Object.keys(genotype);
 

--- a/js/View/Track/SegmentationMultiBin.js
+++ b/js/View/Track/SegmentationMultiBin.js
@@ -2,13 +2,12 @@
 define([
     'dojo/_base/declare',
     'JBrowse/View/Track/Wiggle/XYPlot',
-    'vcfview/Store/SeqFeature/Segmentation'
+    'vcfview/Store/SeqFeature/SegmentationMultiBin'
     ],
-    function(declare, XYPlot, Segmentation) {
+    function(declare, XYPlot, SegmentationMultiBin) {
         return declare(XYPlot, {
             constructor(args) {
-                console.log("testing web integration",args)
-                this.store = new Segmentation(
+                this.store = new SegmentationMultiBin(
                 Object.assign(args, {
                     store: this.store,
                     config: this.config,

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,7 @@ function (
 
             browser.registerTrackType({
                 label: 'VCFSegmentationMultiBin',
-                type: 'vcfview/Store/SeqFeature/SegmentationMultiBin'
+                type: 'vcfview/View/Track/SegmentationMultiBin'
             });
 
             browser.registerTrackType({


### PR DESCRIPTION
This is somewhat technical but the way the store class is initialized is that the track type wraps the storeClass passed in with the segmentation store class


So in trackList.json a given track might look like
    {
      "type": "vcfview/View/Track/SegmentationTrack",
      "storeClass": "JBrowse/Store/SeqFeature/VCFTabix",
      "label": "Segmentation track",
      "urlTemplate": "test.vcf.gz"
    },

Also works to open the track in the file->open track dialog

