### PR TITLE
Dp calc

### DIFF
--- a/js/Store/SeqFeature/VCFExtra.js
+++ b/js/Store/SeqFeature/VCFExtra.js
@@ -1,0 +1,90 @@
+const { TabixIndexedFile } = cjsRequire('@gmod/tabix');
+const VCF = cjsRequire('@gmod/vcf');
+import AbortablePromiseCache from 'abortable-promise-cache';
+import LRU from 'quick-lru';
+define([
+  'dojo/_base/declare',
+  'JBrowse/Store/SeqFeature/VCFTabix',
+  'JBrowse/Model/SimpleFeature',
+  'JBrowse/Model/VCFFeature',
+], function (declare, VCFTabix, SimpleFeature, VCFFeature) {
+  return declare(VCFTabix, {
+    constructor() {
+      this.featureCache = new AbortablePromiseCache({
+        cache: new LRU({
+          maxSize: 20,
+        }),
+        fill: this._readChunk.bind(this),
+      });
+    },
+    async _readChunk(query) {
+      const parser = await this.getParser();
+      const regularizedReferenceName = this.browser.regularizeReferenceName(
+        query.ref,
+      );
+
+      const end = this.browser.view.ref.end;
+      let binSize = 100000;
+      var bins = [];
+      for (let i = 0; i < end; i += binSize) {
+        bins.push({ score: 0, count: 0 });
+      }
+      console.time('vcfextra');
+      await this.indexedData.getLines(
+        regularizedReferenceName,
+        0,
+        undefined,
+        (line, fileOffset) => {
+          try {
+            const variant = parser.parseLine(line);
+            const feature = new VCFFeature({
+              variant: variant,
+              parser: parser,
+              id: 'vcf-' + fileOffset,
+            });
+            const score = (feature.get('genotypes')['NA12877'].DP.values ||
+              [])[0];
+            const start = feature.get('start');
+
+            const featureBin = Math.max(Math.floor(start / binSize), 0);
+            bins[featureBin].score += isNaN(score) ? 0 : score;
+            bins[featureBin].count++;
+            bins[featureBin].start = featureBin * binSize;
+            bins[featureBin].end = (featureBin + 1) * binSize;
+            bins[featureBin].id = fileOffset;
+          } catch (e) {
+            console.error(e);
+          }
+        },
+      );
+      console.timeEnd('vcfextra');
+      return bins;
+    },
+
+    async _getFeatures(
+      query,
+      featureCallback,
+      finishedCallback,
+      errorCallback,
+    ) {
+      try {
+        const features = await this.featureCache.get(query.ref, query);
+        features.forEach(feature => {
+          if (feature.end > query.start && feature.start < query.end) {
+            featureCallback(
+              new SimpleFeature({
+                data: Object.assign(Object.create(feature), {
+                  score: feature.score / feature.count,
+                }),
+              }),
+            );
+          }
+        });
+
+        finishedCallback();
+      } catch (e) {
+        errorCallback(e);
+      }
+    },
+  });
+});

--- a/js/Store/SeqFeature/VCFRawTabix.js
+++ b/js/Store/SeqFeature/VCFRawTabix.js
@@ -1,0 +1,79 @@
+const { TabixIndexedFile } = cjsRequire('@gmod/tabix');
+const VCF = cjsRequire('@gmod/vcf');
+import AbortablePromiseCache from 'abortable-promise-cache';
+import LRU from 'quick-lru';
+define([
+  'dojo/_base/declare',
+  'JBrowse/Store/SeqFeature/VCFTabix',
+  'JBrowse/Model/SimpleFeature',
+], function (declare, VCFTabix, SimpleFeature) {
+  return declare(VCFTabix, {
+    constructor() {
+      this.featureCache = new AbortablePromiseCache({
+        cache: new LRU({
+          maxSize: 20,
+        }),
+        fill: this._readChunk.bind(this),
+      });
+    },
+    async _readChunk(query) {
+      const parser = await this.getParser();
+      const regularizedReferenceName = this.browser.regularizeReferenceName(
+        query.ref,
+      );
+
+      const end = this.browser.view.ref.end;
+      let binSize = 100000;
+      var bins = [];
+      for (let i = 0; i < end; i += binSize) {
+        bins.push({ score: 0, count: 0 });
+      }
+      console.time('vcfraw');
+      await this.indexedData.getLines(
+        regularizedReferenceName,
+        0,
+        undefined,
+        (line, fileOffset) => {
+          const fields = line.split('\t');
+          const start = +fields[1];
+          const score = +fields[9].split(':')[2];
+
+          const featureBin = Math.max(Math.floor(start / binSize), 0);
+          bins[featureBin].score += isNaN(score) ? 0 : score;
+          bins[featureBin].count++;
+          bins[featureBin].start = featureBin * binSize;
+          bins[featureBin].end = (featureBin + 1) * binSize;
+          bins[featureBin].id = fileOffset;
+        },
+      );
+      console.timeEnd('vcfraw');
+      return bins;
+    },
+
+    async _getFeatures(
+      query,
+      featureCallback,
+      finishedCallback,
+      errorCallback,
+    ) {
+      try {
+        const features = await this.featureCache.get(query.ref, query);
+        features.forEach(feature => {
+          if (feature.end > query.start && feature.start < query.end) {
+            featureCallback(
+              new SimpleFeature({
+                data: Object.assign(Object.create(feature), {
+                  score: feature.score / feature.count,
+                }),
+              }),
+            );
+          }
+        });
+
+        finishedCallback();
+      } catch (e) {
+        errorCallback(e);
+      }
+    },
+  });
+});

--- a/test/data/trackList.json
+++ b/test/data/trackList.json
@@ -68,6 +68,22 @@
     {
       "urlTemplate": "inputVcfs/trio.vcf.gz",
       "label": "trio vcf"
+    },
+    {
+      "urlTemplate": "inputVcfs/trio.vcf.gz",
+      "storeClass": "vcfview/Store/SeqFeature/VCFRawTabix",
+      "type": "JBrowse/View/Track/Wiggle/XYPlot",
+      "label": "trio vcf raw DP parser",
+      "chunkSizeLimit": 100000000,
+      "max_score": 100
+    },
+    {
+      "urlTemplate": "inputVcfs/trio.vcf.gz",
+      "storeClass": "vcfview/Store/SeqFeature/VCFExtra",
+      "type": "JBrowse/View/Track/Wiggle/XYPlot",
+      "label": "trio vcf normal DP parser",
+      "chunkSizeLimit": 100000000,
+      "max_score": 100
     }
   ]
 }


### PR DESCRIPTION
This adds a storeclass that calculates from the first sample in the genotypes list the depth

The VCFRawTabix storeclass, which only uses @gmod/tabix and not @gmod/vcf, has processing the entire chr20 at approx 8 seconds
vcfraw: 8053.200927734375ms

The VCFExtra (which uses the full @gmod/tabix and the @gmod/vcf parser) takes about a bit over 2x as long (18 seconds)
vcfextra: 18794.38525390625ms

The VCFExtra does give you some nice features related to VCF parsing but for raw speed using the raw tabix is beneficial. Still not as fast as htslib for example, but this is pure client side js
