### PR TITLE
MultiBigWig with raw tabix parsing

### DIFF
--- a/js/Store/SeqFeature/VCFRawTabix.js
+++ b/js/Store/SeqFeature/VCFRawTabix.js
@@ -18,6 +18,8 @@ define([
     },
     async _readChunk(query) {
       const parser = await this.getParser();
+      const samples = parser.samples;
+
       const regularizedReferenceName = this.browser.regularizeReferenceName(
         query.ref,
       );
@@ -26,9 +28,11 @@ define([
       let binSize = 100000;
       var bins = [];
       for (let i = 0; i < end; i += binSize) {
-        bins.push({ score: 0, count: 0 });
+        bins.push({
+          samples: samples.map(() => ({ score: 0, count: 0 })),
+        });
       }
-      console.time('vcfraw');
+
       await this.indexedData.getLines(
         regularizedReferenceName,
         0,
@@ -36,14 +40,17 @@ define([
         (line, fileOffset) => {
           const fields = line.split('\t');
           const start = +fields[1];
-          const score = +fields[9].split(':')[2];
-
           const featureBin = Math.max(Math.floor(start / binSize), 0);
-          bins[featureBin].score += isNaN(score) ? 0 : score;
-          bins[featureBin].count++;
           bins[featureBin].start = featureBin * binSize;
           bins[featureBin].end = (featureBin + 1) * binSize;
           bins[featureBin].id = fileOffset;
+          for (let i = 0; i < samples.length; i++) {
+            const sampleName = samples[i];
+            const score = +fields[9 + i].split(':')[2];
+            bins[featureBin].samples[i].score += isNaN(score) ? 0 : score;
+            bins[featureBin].samples[i].count++;
+            bins[featureBin].samples[i].source = sampleName;
+          }
         },
       );
       console.timeEnd('vcfraw');
@@ -60,13 +67,16 @@ define([
         const features = await this.featureCache.get(query.ref, query);
         features.forEach(feature => {
           if (feature.end > query.start && feature.start < query.end) {
-            featureCallback(
-              new SimpleFeature({
-                data: Object.assign(Object.create(feature), {
-                  score: feature.score / feature.count,
+            feature.samples.forEach(sample => {
+              featureCallback(
+                new SimpleFeature({
+                  data: Object.assign(Object.create(feature), {
+                    score: sample.score / sample.count,
+                    source: sample.source,
+                  }),
                 }),
-              }),
-            );
+              );
+            });
           }
         });
 

--- a/test/data/trackList.json
+++ b/test/data/trackList.json
@@ -91,12 +91,12 @@
       "type": "MultiBigWig/View/Track/MultiWiggle/MultiXYPlot",
       "label": "trio vcf multibigwig",
       "chunkSizeLimit": 100000000,
-      "max_score": 100,
+      "max_score": 5,
+      "min_score": -5,
       "urlTemplates": [
         { "name": "NA12877", "color": "green" },
         { "name": "NA12878", "color": "orange" },
-        { "name": "NA12882", "color": "blue" },
-        { "name": "mean", "color": "black" }
+        { "name": "NA12882", "color": "blue" }
       ]
     }
   ]

--- a/test/data/trackList.json
+++ b/test/data/trackList.json
@@ -84,6 +84,20 @@
       "label": "trio vcf normal DP parser",
       "chunkSizeLimit": 100000000,
       "max_score": 100
+    },
+    {
+      "urlTemplate": "inputVcfs/trio.vcf.gz",
+      "storeClass": "vcfview/Store/SeqFeature/VCFRawTabix",
+      "type": "MultiBigWig/View/Track/MultiWiggle/MultiXYPlot",
+      "label": "trio vcf multibigwig",
+      "chunkSizeLimit": 100000000,
+      "max_score": 100,
+      "urlTemplates": [
+        { "name": "NA12877", "color": "green" },
+        { "name": "NA12878", "color": "orange" },
+        { "name": "NA12882", "color": "blue" },
+        { "name": "mean", "color": "black" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This proposes multibigwig display of the genotypes in the VCF

The trackList.json must be preloaded with the names of the samples for the multi-bigwig but this may be a step in the right direction

It also adds simple z-score scaling to the samples

![localhost_jbrowse__data=plugins%2Fvcfview%2Ftest%2Fdata loc=20%3A17940860 17940928 tracks=DNA%2Ctrio%20vcf%20multibigwig highlight=](https://user-images.githubusercontent.com/6511937/89371420-531a2800-d6b1-11ea-8025-24f96fae4942.png)



